### PR TITLE
fix(connect): register v1 OwnerService route to fix text/plain fallthrough

### DIFF
--- a/.planning/debug/buf-v1-owner-route-missing.md
+++ b/.planning/debug/buf-v1-owner-route-missing.md
@@ -1,0 +1,82 @@
+---
+status: resolved
+trigger: "Failure: could not get module data for remote module \"buf-proxy.yadro.dev/googleapis/googleapis\": unknown: invalid content-type: \"text/plain; charset=utf-8\"; expecting \"application/proto\" — buf CLI v1 path /buf.registry.owner.v1.OwnerService/GetOwners falls through to text/plain rootHandler"
+created: 2026-06-24
+updated: 2026-06-24
+---
+
+# Debug Session: buf-v1-owner-route-missing
+
+## Symptoms
+
+- **Expected behavior:** `buf dep update` succeeds when remote module is `buf-proxy.yadro.dev/googleapis/googleapis`
+- **Actual behavior:** `Failure: could not get module data for remote module "buf-proxy.yadro.dev/googleapis/googleapis": unknown: invalid content-type: "text/plain; charset=utf-8"; expecting "application/proto"`
+- **Error messages:** buf CLI receives `text/plain; charset=utf-8` body of 62 bytes (the "Hello!" health-check string) when calling `POST /buf.registry.owner.v1.OwnerService/GetOwners`
+- **Timeline:** Surfaced after the v1 module/commit/graph/download routes were registered (commits `8cf1da5` and `2e88320`). Same class of bug as the resolved `buf-v2-content-type` issue, but for the Owner service.
+- **Reproduction:** `buf dep update` against `buf-proxy.yadro.dev/googleapis/googleapis` from a v2 buf.yaml config.
+- **Key clue:** Log line `request completed ... path:"/buf.registry.owner.v1.OwnerService/GetOwners" status:200 size:62 content_type:"application/proto" duration:22781` — the 62-byte body is exactly the `rootHandler` "Hello! This is Buf Proxy Service and this is its Health Check!" string. The `content_type:"application/proto"` is the request content-type, not the response; the response content-type is `text/plain; charset=utf-8` (Go's default for `w.Write([]byte(...))`).
+
+## Current Focus
+
+- hypothesis: "The proxy has no handler registered for /buf.registry.owner.v1.OwnerService/ so requests fall through to the text/plain rootHandler."
+- test: "Verify by checking route registrations in internal/connect/api.go and matching against log entries for /buf.registry.owner.v1.OwnerService/*."
+- expecting: "api.go missing mux.Handle on the v1 OwnerService path, matching exactly the prior buf-v2-content-type bug class."
+- next_action: "Confirm and apply the fix (register the v1 OwnerService handler)."
+- reasoning_checkpoint: null
+
+## Evidence
+
+- timestamp: 2026-06-24T12:35
+  type: log_search
+  file: logs/prod-buf-proxy-buf-proxy-858bbb4bb7-6dcdn-buf-proxy.log
+  finding: "Log line 203-204: request_id=8c54d3c86a92e29368ac75aa90f13909, method=POST, path=/buf.registry.owner.v1.OwnerService/GetOwners, body_size=36, content_type=application/proto, user_agent=connect-go/1.19.2 (go1.26.3), status=200, size=62, duration=22781ns. size=62 matches the rootHandler string byte length exactly."
+
+- timestamp: 2026-06-24T12:35
+  type: log_search
+  file: logs/prod-buf-proxy-buf-proxy-858bbb4bb7-6dcdn-buf-proxy.log
+  finding: "Log line 222-223 and 1125-1126: identical pattern (status=200, size=62) for /buf.registry.owner.v1.OwnerService/GetOwners from client_ip=192.168.53.189, with body_size=36 and content_type=application/proto. Each call is a clean 200 with a 62-byte body — Go net/http default for the rootHandler text response."
+
+- timestamp: 2026-06-24T12:35
+  type: code_analysis
+  file: internal/connect/api.go:47-72
+  finding: "Registered routes are: v1alpha1 (Resolve/Repository/Download via connect-generated handlers), v1 + v1beta1 (Commit/Graph/Download/Module) for buf CLI 1.69.0+ compatibility. NO registration for /buf.registry.owner.v1.OwnerService/ — that path is not handled by any mux.Handle and falls through to the catch-all rootHandler at line 70."
+
+- timestamp: 2026-06-24T12:35
+  type: code_analysis
+  file: internal/connect/api.go:29-32
+  finding: "rootHandler does w.WriteHeader(200) + w.Write([]byte('Hello! This is Buf Proxy Service and this is its Health Check!')) — Go's net/http sets Content-Type to text/plain; charset=utf-8 by default for []byte writes without a prior Set/Header call. The string is exactly 62 bytes, matching the response size in the log."
+
+- timestamp: 2026-06-24T12:35
+  type: code_analysis
+  file: gen/proto/buf/alpha/registry/v1alpha1/v1alpha1connect/owner.connect.go
+  finding: "The v1alpha1 owner.connect.go is generated and exported (v1alpha1connect.NewOwnerServiceHandler, v1alpha1connect.UnimplementedOwnerServiceHandler), but the API has no v1 path registration for OwnerService. The buf CLI uses /buf.registry.owner.v1.OwnerService/GetOwners — a v1 path that has no handler. The v1alpha1 path is registered via mux.Handle on line 49-51, but only for Resolve/Repository/Download."
+
+- timestamp: 2026-06-24T12:35
+  type: history_check
+  file: .planning/debug/buf-v2-content-type.md (resolved)
+  finding: "Identical class of bug resolved previously: missing v1 path registrations for CommitService/GraphService/DownloadService caused text/plain fallthrough. Fix pattern was to add v1 mux.HandleFunc calls mirroring the v1beta1 routes. The same pattern needs to be applied for OwnerService at /buf.registry.owner.v1.OwnerService/."
+
+## Eliminated
+
+- hypothesis: "Proxy returns text/plain because the request body itself is wrong."
+  evidence: "Request body is 36 bytes with content_type=application/proto (line 203). The buf CLI is sending the correct request format. The 200 status with size=62 body is the proxy's own response, not the request."
+  timestamp: 2026-06-24T12:35
+
+- hypothesis: "The text/plain response comes from a health-check handler accidentally matching the path."
+  evidence: "The rootHandler at api.go:29 IS the health-check handler. It matches via the catch-all / route at api.go:70 because no more specific route is registered for /buf.registry.owner.v1.OwnerService/. Same mechanism as the resolved buf-v2-content-type bug."
+  timestamp: 2026-06-24T12:35
+
+- hypothesis: "The buf CLI should be calling a v1alpha1 path, not a v1 path, so this is a client misconfiguration."
+  evidence: "Buf CLI v1.69.0+ uses v1 paths (as documented in the resolved buf-v1-graph-format session) for module operations. The buf CLI is correctly using /buf.registry.owner.v1.OwnerService/GetOwners — it's the proxy that fails to register this route."
+  timestamp: 2026-06-24T12:35
+
+## Resolution
+
+- root_cause: "Missing v1 route registration for /buf.registry.owner.v1.OwnerService/ in internal/connect/api.go. The buf CLI calls OwnerService/GetOwners as part of the v1 module-dep workflow; without a registered handler the request fell through to the text/plain rootHandler (returning 62 bytes of the health-check string), which the buf CLI rejected with the content-type mismatch error."
+- fix: "Add a hand-written v1 OwnerService handler that parses GetOwnersRequest, looks up each requested owner against the configured repository set (id and name forms both supported), and returns a synthetic GetOwnersResponse with one Owner{Organization{id, name}} per matched owner. Wire it up in api.go alongside the existing v1/v1beta1 module/owner/commit/graph/download routes. Use raw protowire.Append* to stay consistent with the v1 commit/graph/download handlers and avoid pulling the buf.build v1 owner module as a Go dependency."
+- verification: "go build ./... clean. go vet ./... clean. All existing tests pass. 6 new tests pass: route registered, application/proto response for known owner, by-id and by-name lookup forms, unknown-owner omitted, empty body returns 400, GET returns 405."
+- files_changed:
+  - internal/connect/api.go (add Repositories() to provider interface, build knownOwners map at startup, register the new route)
+  - internal/connect/owners.go (new — ServeGetOwners handler + parse/build helpers)
+  - internal/connect/commits.go (add knownOwners field to commitServiceHandler struct)
+  - internal/connect/api_test.go (mockSource + Repositories on mockProvider + 6 new tests)

--- a/internal/connect/api.go
+++ b/internal/connect/api.go
@@ -10,11 +10,13 @@ import (
 
 	v1alpha1connect "github.com/easyp-tech/server/gen/proto/buf/alpha/registry/v1alpha1/v1alpha1connect"
 	"github.com/easyp-tech/server/internal/providers/content"
+	"github.com/easyp-tech/server/internal/providers/source"
 )
 
 type provider interface {
 	GetMeta(ctx context.Context, owner, repoName, commit string) (content.Meta, error)
 	GetFiles(ctx context.Context, owner, repoName, commit string) ([]content.File, error)
+	Repositories() []source.Source
 }
 
 type api struct {
@@ -53,10 +55,17 @@ func New(
 	// CommitService/GraphService/DownloadService handlers for buf CLI v1.69.0+.
 	// Both v1 and v1beta1 paths are registered because buf CLI uses v1beta1
 	// paths with v1 buf.yaml config and v1 paths with v2 buf.yaml config.
+	// OwnerService is also part of the v1 API surface that buf CLI calls
+	// during `buf dep update`; without it the request falls through to the
+	// catch-all rootHandler and the client sees a text/plain response,
+	// which the buf CLI rejects with "invalid content-type: ... expecting
+	// application/proto".
+	knownOwners := buildKnownOwners(core.Repositories())
 	commitHandler := &commitServiceHandler{
 		api: a, commitMap: make(map[string]moduleRef),
-		infoCache: make(map[string]commitInfoCache),
-		filesMap:  make(map[string][]content.File),
+		infoCache:   make(map[string]commitInfoCache),
+		filesMap:    make(map[string][]content.File),
+		knownOwners: knownOwners,
 	}
 	mux.HandleFunc("/buf.registry.module.v1.CommitService/", commitHandler.ServeHTTP)
 	mux.HandleFunc("/buf.registry.module.v1beta1.CommitService/", commitHandler.ServeHTTP)
@@ -66,6 +75,7 @@ func New(
 	mux.HandleFunc("/buf.registry.module.v1beta1.DownloadService/", commitHandler.ServeDownload)
 	mux.HandleFunc("/buf.registry.module.v1.ModuleService/", commitHandler.ServeGetModules)
 	mux.HandleFunc("/buf.registry.module.v1beta1.ModuleService/", commitHandler.ServeGetModules)
+	mux.HandleFunc("/buf.registry.owner.v1.OwnerService/", commitHandler.ServeGetOwners)
 
 	mux.HandleFunc("/", rootHandler)
 

--- a/internal/connect/api_test.go
+++ b/internal/connect/api_test.go
@@ -15,6 +15,7 @@ import (
 	registry "github.com/easyp-tech/server/gen/proto/buf/alpha/registry/v1alpha1"
 	v1alpha1connect "github.com/easyp-tech/server/gen/proto/buf/alpha/registry/v1alpha1/v1alpha1connect"
 	"github.com/easyp-tech/server/internal/providers/content"
+	"github.com/easyp-tech/server/internal/providers/source"
 	"github.com/easyp-tech/server/internal/shake256"
 	"google.golang.org/protobuf/encoding/protowire"
 )
@@ -26,9 +27,10 @@ var errUpstream = errors.New("upstream is down")
 
 // mockProvider implements provider for testing.
 type mockProvider struct {
-	meta  content.Meta
-	files []content.File
-	err   error
+	meta    content.Meta
+	files   []content.File
+	err     error
+	repos   []source.Source
 }
 
 func (m *mockProvider) GetMeta(_ context.Context, _, _, _ string) (content.Meta, error) {
@@ -37,6 +39,43 @@ func (m *mockProvider) GetMeta(_ context.Context, _, _, _ string) (content.Meta,
 
 func (m *mockProvider) GetFiles(_ context.Context, _, _, _ string) ([]content.File, error) {
 	return m.files, m.err
+}
+
+func (m *mockProvider) Repositories() []source.Source {
+	return m.repos
+}
+
+// mockSource is a source.Source that returns canned metadata for
+// OwnerService tests. It only implements the methods needed for
+// buildKnownOwners (Owner, RepoName) plus the Source interface contract
+// that the rest of the package relies on.
+type mockSource struct {
+	owner    string
+	repoName string
+	typ      string
+}
+
+func (s *mockSource) GetMeta(_ context.Context, _ string) (content.Meta, error) {
+	return content.Meta{}, nil
+}
+
+func (s *mockSource) GetFiles(_ context.Context, _ string) ([]content.File, error) {
+	return nil, nil
+}
+
+func (s *mockSource) ConfigHash() string { return "mock" }
+
+func (s *mockSource) Name() string { return s.repoName }
+
+func (s *mockSource) Owner() string { return s.owner }
+
+func (s *mockSource) RepoName() string { return s.repoName }
+
+func (s *mockSource) Type() string {
+	if s.typ == "" {
+		return "mock"
+	}
+	return s.typ
 }
 
 func testMux(p provider) *http.ServeMux {
@@ -659,4 +698,288 @@ func TestHandlerError_UpstreamError_UsesModuleKey(t *testing.T) {
 	// for the user-facing per-request line. The canonical key for the
 	// module-level lookup is still `module` (verified by the assertions above);
 	// `repo` is supplementary.
+}
+
+// --- OwnerService tests ---
+
+// buildGetOwnersRequestByID builds a GetOwnersRequest containing one
+// OwnerRef with the given id (the buf-style deterministic id form).
+func buildGetOwnersRequestByID(id string) []byte {
+	// OwnerRef: id = field 1, string
+	var ref []byte
+	ref = protowire.AppendTag(ref, 1, protowire.BytesType)
+	ref = protowire.AppendString(ref, id)
+	// GetOwnersRequest: owner_refs = field 1, repeated message
+	var req []byte
+	req = protowire.AppendTag(req, 1, protowire.BytesType)
+	req = append(req, protowire.AppendVarint(nil, uint64(len(ref)))...)
+	req = append(req, ref...)
+	return req
+}
+
+// buildGetOwnersRequestByName builds a GetOwnersRequest containing one
+// OwnerRef with the given name (the owner name form like "googleapis").
+func buildGetOwnersRequestByName(name string) []byte {
+	// OwnerRef: name = field 2, string
+	var ref []byte
+	ref = protowire.AppendTag(ref, 2, protowire.BytesType)
+	ref = protowire.AppendString(ref, name)
+	var req []byte
+	req = protowire.AppendTag(req, 1, protowire.BytesType)
+	req = append(req, protowire.AppendVarint(nil, uint64(len(ref)))...)
+	req = append(req, ref...)
+	return req
+}
+
+// extractOwnerNameFromResponse walks a GetOwnersResponse body and
+// returns the Organization.name of the first owner, or "" if no owners
+// are present.
+//
+// GetOwnersResponse: repeated Owner owners = 1
+// Owner: oneof { Organization organization = 2 }
+// Organization: id=1, name=4
+func extractOwnerNameFromResponse(body []byte) string {
+	for len(body) > 0 {
+		num, typ, n := protowire.ConsumeTag(body)
+		if n < 0 {
+			return ""
+		}
+		body = body[n:]
+		if num == 1 && typ == protowire.BytesType {
+			owner, mLen := protowire.ConsumeBytes(body)
+			body = body[mLen:]
+			// owner is Owner: skip into the Organization submessage (field 2)
+			for len(owner) > 0 {
+				oNum, oTyp, oN := protowire.ConsumeTag(owner)
+				if oN < 0 {
+					return ""
+				}
+				owner = owner[oN:]
+				if oNum == 2 && oTyp == protowire.BytesType {
+					org, _ := protowire.ConsumeBytes(owner)
+					// Organization: id=1, name=4
+					for len(org) > 0 {
+						fNum, fTyp, fN := protowire.ConsumeTag(org)
+						if fN < 0 {
+							return ""
+						}
+						org = org[fN:]
+						if fNum == 4 && fTyp == protowire.BytesType {
+							name, _ := protowire.ConsumeBytes(org)
+							return string(name)
+						}
+						fN = protowire.ConsumeFieldValue(fNum, fTyp, org)
+						if fN < 0 {
+							return ""
+						}
+						org = org[fN:]
+					}
+				} else {
+					oN = protowire.ConsumeFieldValue(oNum, oTyp, owner)
+					if oN < 0 {
+						return ""
+					}
+					owner = owner[oN:]
+				}
+			}
+		} else {
+			n = protowire.ConsumeFieldValue(num, typ, body)
+			if n < 0 {
+				return ""
+			}
+			body = body[n:]
+		}
+	}
+	return ""
+}
+
+// TestOwnerServiceV1RouteRegistered pins the bug fix: a POST to the v1
+// OwnerService path must NOT fall through to the text/plain rootHandler.
+// Returns 200 application/proto (or 400 if the request body is empty),
+// never 200 with text/plain content-type.
+func TestOwnerServiceV1RouteRegistered(t *testing.T) {
+	p := &mockProvider{}
+	mux := testMux(p)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp, err := http.Post(
+		server.URL+"/buf.registry.owner.v1.OwnerService/GetOwners",
+		"application/proto",
+		bytes.NewReader(nil),
+	)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ct := resp.Header.Get("Content-Type")
+	if resp.StatusCode == http.StatusOK && ct == "text/plain; charset=utf-8" {
+		t.Errorf("path /buf.registry.owner.v1.OwnerService/ not registered — fell through to rootHandler (200 text/plain)")
+	}
+}
+
+// TestOwnerServiceV1ReturnsProtobuf pins the fix at the protocol level:
+// when a known owner is requested, the response must be application/proto
+// with a non-empty body containing the owner name. This is the exact
+// path that was failing in prod with the text/plain content-type error.
+func TestOwnerServiceV1ReturnsProtobuf(t *testing.T) {
+	p := &mockProvider{
+		repos: []source.Source{
+			&mockSource{owner: "googleapis", repoName: "googleapis", typ: "github"},
+		},
+	}
+	mux := testMux(p)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	body := buildGetOwnersRequestByID(deterministicID("googleapis"))
+	resp, err := http.Post(
+		server.URL+"/buf.registry.owner.v1.OwnerService/GetOwners",
+		"application/proto",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); ct != "application/proto" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/proto")
+	}
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, respBody)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	if len(respBody) == 0 {
+		t.Fatal("empty response body")
+	}
+	if got := extractOwnerNameFromResponse(respBody); got != "googleapis" {
+		t.Errorf("owner name = %q, want %q; body: %x", got, "googleapis", respBody)
+	}
+}
+
+// TestOwnerServiceV1ByName verifies the handler accepts an OwnerRef with
+// a name (the form the buf CLI uses when it knows the owner name but not
+// the cached id, e.g. on a fresh machine).
+func TestOwnerServiceV1ByName(t *testing.T) {
+	p := &mockProvider{
+		repos: []source.Source{
+			&mockSource{owner: "googleapis", repoName: "googleapis"},
+		},
+	}
+	mux := testMux(p)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	body := buildGetOwnersRequestByName("googleapis")
+	resp, err := http.Post(
+		server.URL+"/buf.registry.owner.v1.OwnerService/GetOwners",
+		"application/proto",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, respBody)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/proto" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/proto")
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	if got := extractOwnerNameFromResponse(respBody); got != "googleapis" {
+		t.Errorf("owner name = %q, want %q; body: %x", got, "googleapis", respBody)
+	}
+}
+
+// TestOwnerServiceV1UnknownOwner pins the "we don't fabricate owners we
+// don't serve" rule: an owner that is not in the configured repository
+// set must NOT be returned, even if its id matches the buf-style format.
+// This protects against the proxy accidentally answering for owners it
+// has no information about.
+func TestOwnerServiceV1UnknownOwner(t *testing.T) {
+	p := &mockProvider{
+		repos: []source.Source{
+			&mockSource{owner: "googleapis", repoName: "googleapis"},
+		},
+	}
+	mux := testMux(p)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Build a request for an owner the proxy does NOT serve.
+	body := buildGetOwnersRequestByID(deterministicID("not-a-real-owner"))
+	resp, err := http.Post(
+		server.URL+"/buf.registry.owner.v1.OwnerService/GetOwners",
+		"application/proto",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (empty body is correct for unknown owner)", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/proto" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/proto")
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	if got := extractOwnerNameFromResponse(respBody); got != "" {
+		t.Errorf("owner name = %q, want empty (unknown owner must not be returned); body: %x", got, respBody)
+	}
+}
+
+// TestOwnerServiceV1EmptyBody pins the 400 path: an empty body has no
+// owner refs to look up, so the handler must return 400, not 200. The
+// 400 body uses Go's standard http.Error text/plain (this is the same
+// pattern used by every other bad-request path in this package).
+func TestOwnerServiceV1EmptyBody(t *testing.T) {
+	p := &mockProvider{}
+	mux := testMux(p)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp, err := http.Post(
+		server.URL+"/buf.registry.owner.v1.OwnerService/GetOwners",
+		"application/proto",
+		bytes.NewReader(nil),
+	)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (empty body has no owner refs)", resp.StatusCode)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(respBody, []byte("no owner refs")) {
+		t.Errorf("body %q does not mention 'no owner refs'", respBody)
+	}
+}
+
+// TestOwnerServiceV1MethodNotAllowed pins the 405 path: GET is rejected
+// at the handler entry, never reaching the rootHandler.
+func TestOwnerServiceV1MethodNotAllowed(t *testing.T) {
+	p := &mockProvider{}
+	mux := testMux(p)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/buf.registry.owner.v1.OwnerService/GetOwners")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusMethodNotAllowed)
+	}
 }

--- a/internal/connect/commits.go
+++ b/internal/connect/commits.go
@@ -32,6 +32,11 @@ type commitServiceHandler struct {
 	commitMap map[string]moduleRef       // commitID → owner/module
 	infoCache map[string]commitInfoCache // "owner/module" → cached commit info
 	filesMap  map[string][]content.File  // commitID → cached files
+	// knownOwners is a deterministic-id → owner-name lookup populated
+	// at startup from the configured repositories. Used by the
+	// buf.registry.owner.v1.OwnerService/GetOwners handler to answer
+	// owner-info lookups from the buf CLI during `buf dep update`.
+	knownOwners map[string]string
 }
 
 // hlog returns a logger that carries the per-request correlation id so

--- a/internal/connect/owners.go
+++ b/internal/connect/owners.go
@@ -1,0 +1,228 @@
+package connect
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+
+	"google.golang.org/protobuf/encoding/protowire"
+
+	"github.com/easyp-tech/server/internal/providers/source"
+)
+
+// ownerRef is a parsed OwnerRef from a GetOwnersRequest body.
+// Exactly one of id or name is populated per the proto oneof rule.
+type ownerRef struct {
+	id   string
+	name string
+}
+
+// ServeGetOwners handles buf.registry.owner.v1.OwnerService/GetOwners.
+//
+// The buf CLI calls this RPC during `buf dep update` to resolve the owner
+// of each dependency (e.g. "googleapis" of googleapis/googleapis). The
+// request body is a GetOwnersRequest with repeated OwnerRef entries —
+// each OwnerRef is a oneof, either an id (buf-style deterministic id) or
+// a name (the owner name like "googleapis").
+//
+// We respond with a synthetic Organization for every requested owner that
+// matches a known configured owner, in the same order as requested.
+// Unknown owners are omitted (buf CLI treats an empty slot in the
+// response list as "owner not found", which is the right answer for
+// owners this proxy does not serve).
+//
+// The handler mirrors the wire-level approach used by the other v1
+// handlers in this package: raw protowire.Append* calls, no generated
+// proto types. This avoids pulling the buf.build v1 owner module as a
+// Go dependency and keeps the handler consistent with the v1
+// CommitService/GraphService/DownloadService/ModuleService handlers.
+func (h *commitServiceHandler) ServeGetOwners(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.logHandlerError(r, w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		h.badRequest(r, w, "reading body", slog.String("read_error", err.Error()))
+		return
+	}
+
+	refs := parseGetOwnersRequest(body)
+	h.hlog(r).LogAttrs(r.Context(), slog.LevelInfo, "handler decision",
+		slog.String("handler", "ServeGetOwners"),
+		slog.String("procedure", "OwnerService/GetOwners"),
+		slog.Int("refs", len(refs)),
+		slog.Int("body_bytes", len(body)),
+	)
+	if len(refs) == 0 {
+		h.badRequest(r, w, "no owner refs", slog.Int("body_bytes", len(body)))
+		return
+	}
+
+	// Resolve each requested owner against the configured set. We match by
+	// id first (the buf CLI usually sends the deterministic id it already
+	// has cached) and fall back to name lookup.
+	var respMsg []byte
+	for _, ref := range refs {
+		name := h.resolveOwnerName(ref)
+		if name == "" {
+			h.hlog(r).LogAttrs(r.Context(), slog.LevelInfo, "handler decision",
+				slog.String("handler", "ServeGetOwners"),
+				slog.String("procedure", "OwnerService/GetOwners"),
+				slog.String("branch", "owner_resolve"),
+				slog.String("outcome", "not_found"),
+				slog.String("requested_id", ref.id),
+				slog.String("requested_name", ref.name),
+			)
+			continue
+		}
+		h.hlog(r).LogAttrs(r.Context(), slog.LevelInfo, "handler decision",
+			slog.String("handler", "ServeGetOwners"),
+			slog.String("procedure", "OwnerService/GetOwners"),
+			slog.String("branch", "owner_resolve"),
+			slog.String("outcome", "matched"),
+			slog.String("owner", name),
+		)
+		owner := buildOwnerOrganization(deterministicID(name), name)
+		respMsg = protowire.AppendTag(respMsg, 1, protowire.BytesType)
+		respMsg = append(respMsg, protowire.AppendVarint(nil, uint64(len(owner)))...)
+		respMsg = append(respMsg, owner...)
+	}
+
+	w.Header().Set("Content-Type", "application/proto")
+	_, _ = w.Write(respMsg)
+}
+
+// resolveOwnerName maps a parsed OwnerRef to the owner name string,
+// using the knownOwners map built at startup. Returns empty string if
+// the owner is not in the configured set.
+func (h *commitServiceHandler) resolveOwnerName(ref ownerRef) string {
+	if ref.id != "" {
+		if name, ok := h.knownOwners[ref.id]; ok {
+			return name
+		}
+		return ""
+	}
+	if ref.name != "" {
+		// Validate the name is in our known set so we don't fabricate
+		// owners we don't serve.
+		id := deterministicID(ref.name)
+		if _, ok := h.knownOwners[id]; ok {
+			return ref.name
+		}
+		return ""
+	}
+	return ""
+}
+
+// buildKnownOwners builds the id → name lookup used by ServeGetOwners.
+// It iterates the configured repositories and collects the unique set of
+// owner names, computing the buf-style deterministic id for each.
+//
+// The map is built once at startup from the source list. Owners can be
+// added by configuring a new repository; the proxy does not need to
+// populate this map dynamically from request traffic.
+func buildKnownOwners(repos []source.Source) map[string]string {
+	out := make(map[string]string, len(repos))
+	for _, repo := range repos {
+		name := repo.Owner()
+		if name == "" {
+			continue
+		}
+		out[deterministicID(name)] = name
+	}
+	return out
+}
+
+// parseGetOwnersRequest extracts the repeated OwnerRef entries from a
+// GetOwnersRequest body.
+//
+// GetOwnersRequest: repeated OwnerRef owner_refs = 1
+// OwnerRef: oneof { string id = 1; string name = 2 }
+func parseGetOwnersRequest(msg []byte) []ownerRef {
+	var refs []ownerRef
+	for len(msg) > 0 {
+		num, typ, n := protowire.ConsumeTag(msg)
+		if n < 0 {
+			break
+		}
+		msg = msg[n:]
+		if num == 1 && typ == protowire.BytesType {
+			v, mLen := protowire.ConsumeBytes(msg)
+			msg = msg[mLen:]
+			if ref := parseOwnerRef(v); ref != nil {
+				refs = append(refs, *ref)
+			}
+		} else {
+			n = protowire.ConsumeFieldValue(num, typ, msg)
+			if n < 0 {
+				break
+			}
+			msg = msg[n:]
+		}
+	}
+	return refs
+}
+
+// parseOwnerRef extracts the id or name from a single OwnerRef message.
+// Per the proto oneof, at most one of id or name will be set.
+func parseOwnerRef(msg []byte) *ownerRef {
+	var ref ownerRef
+	for len(msg) > 0 {
+		num, typ, n := protowire.ConsumeTag(msg)
+		if n < 0 {
+			break
+		}
+		msg = msg[n:]
+		if num == 1 && typ == protowire.BytesType {
+			v, mLen := protowire.ConsumeBytes(msg)
+			msg = msg[mLen:]
+			ref.id = string(v)
+		} else if num == 2 && typ == protowire.BytesType {
+			v, mLen := protowire.ConsumeBytes(msg)
+			msg = msg[mLen:]
+			ref.name = string(v)
+		} else {
+			n = protowire.ConsumeFieldValue(num, typ, msg)
+			if n < 0 {
+				break
+			}
+			msg = msg[n:]
+		}
+	}
+	if ref.id == "" && ref.name == "" {
+		return nil
+	}
+	return &ref
+}
+
+// buildOwnerOrganization builds an Owner message wrapping an
+// Organization. The Owner proto is a oneof with User (field 1) and
+// Organization (field 2); we emit field 2.
+//
+// Organization fields: id=1, create_time=2, update_time=3, name=4.
+func buildOwnerOrganization(id, name string) []byte {
+	org := buildOrganization(id, name)
+	// Owner.organization = field 2, length-delimited submessage
+	var owner []byte
+	owner = protowire.AppendTag(owner, 2, protowire.BytesType)
+	owner = append(owner, protowire.AppendVarint(nil, uint64(len(org)))...)
+	owner = append(owner, org...)
+	return owner
+}
+
+// buildOrganization builds an Organization message with id, name, and
+// zero timestamps. We deliberately omit create_time/update_time to keep
+// the response minimal — buf CLI does not require them to be populated
+// for owner lookup during `buf dep update`.
+func buildOrganization(id, name string) []byte {
+	var org []byte
+	// id = field 1 (string)
+	org = protowire.AppendTag(org, 1, protowire.BytesType)
+	org = protowire.AppendString(org, id)
+	// name = field 4 (string)
+	org = protowire.AppendTag(org, 4, protowire.BytesType)
+	org = protowire.AppendString(org, name)
+	return org
+}


### PR DESCRIPTION
## Summary

Fixes `Failure: could not get module data for remote module "buf-proxy.yadro.dev/googleapis/googleapis": unknown: invalid content-type: "text/plain; charset=utf-8"; expecting "application/proto"`.

The buf CLI calls `OwnerService/GetOwners` during `buf dep update` to resolve the owner of each dependency. The proxy registered v1 routes for Commit/Graph/Download/Module services (commit 8cf1da5) but missed `/buf.registry.owner.v1.OwnerService/`. The request fell through to the catch-all `rootHandler` which returned the 62-byte health-check string with `text/plain; charset=utf-8` — Go's net/http default for raw `w.Write([]byte(...))`. The buf CLI rejected the response with the content-type mismatch error above.

## Root cause

Same class of bug as 8cf1da5: `internal/connect/api.go` was missing a route registration. The `rootHandler` registered at `/` (line 70) acts as a catch-all and returns text/plain for any unhandled path. The 62-byte body in the prod log is exactly the byte length of the `rootHandler`'s `"Hello! This is Buf Proxy Service and this is its Health Check!"` string.

## Fix

Add a hand-written v1 OwnerService handler that:
- Parses `GetOwnersRequest` (supports both `OwnerRef.id` and `OwnerRef.name` forms — the buf CLI can send either).
- Looks up each requested owner against a `knownOwners` map built at startup from `provider.Repositories()`. Each entry is `deterministicID(name) → name`, matching the `owner_id` field that `CommitService/GetCommits` and `CommitService/GetGraph` already return for the same owner.
- Returns a synthetic `GetOwnersResponse` with one `Owner{Organization{id, name}}` per matched owner. Unknown owners are omitted rather than fabricated.

Uses raw `protowire.Append*` calls to stay consistent with the v1 commit/graph/download handlers and avoid pulling the buf.build v1 owner module as a Go dependency.

## Files

- `internal/connect/api.go` — add `Repositories()` to the `provider` interface, build `knownOwners` map at startup, register the new route
- `internal/connect/owners.go` — new file: `ServeGetOwners` handler + parse/build helpers
- `internal/connect/commits.go` — add `knownOwners` field to `commitServiceHandler`
- `internal/connect/api_test.go` — `mockSource` + `Repositories` on `mockProvider` + 6 new tests
- `.planning/debug/buf-v1-owner-route-missing.md` — debug session record

## Tests

All existing tests pass. 6 new tests cover the regression class:

- `TestOwnerServiceV1RouteRegistered` — pins the bug: route no longer falls through to text/plain
- `TestOwnerServiceV1ReturnsProtobuf` — by-id lookup returns `application/proto` with the right owner
- `TestOwnerServiceV1ByName` — by-name lookup also works
- `TestOwnerServiceV1UnknownOwner` — owners the proxy doesn't serve are omitted, not fabricated
- `TestOwnerServiceV1EmptyBody` — empty body returns 400, not 200 text/plain
- `TestOwnerServiceV1MethodNotAllowed` — GET returns 405

`go build ./...` clean, `go vet ./...` clean, `go test ./...` all packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)